### PR TITLE
Use default back button for list template

### DIFF
--- a/ios/RNCarPlay.m
+++ b/ios/RNCarPlay.m
@@ -148,11 +148,6 @@ RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)co
         CPListTemplate *listTemplate = [[CPListTemplate alloc] initWithTitle:title sections:sections];
         [listTemplate setLeadingNavigationBarButtons:leadingNavigationBarButtons];
         [listTemplate setTrailingNavigationBarButtons:trailingNavigationBarButtons];
-        CPBarButton *backButton = [[CPBarButton alloc] initWithTitle:@" Back" handler:^(CPBarButton * _Nonnull barButton) {
-            [self sendEventWithName:@"backButtonPressed" body:@{@"templateId":templateId}];
-            [self popTemplate:true];
-        }];
-        [listTemplate setBackButton:backButton];
         if (config[@"emptyViewTitleVariants"]) {
             listTemplate.emptyViewTitleVariants = [RCTConvert NSArray:config[@"emptyViewTitleVariants"]];
         }


### PR DESCRIPTION
This solves the hardcoded string "Back" and uses the default implementation which shows the title of the previous template.